### PR TITLE
docker 기반으로 웹 서버 실행 할 수 있도록 초기화 스크립트 및 설정 변경, 배포 자동화를 스크립트 추가

### DIFF
--- a/aws_cdk/web_cdk/ec2.py
+++ b/aws_cdk/web_cdk/ec2.py
@@ -25,6 +25,8 @@ class Ec2CdkStack(core.Stack):
             )
             default_role.add_managed_policy(
                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore"))
+            default_role.add_managed_policy(
+                iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2ContainerRegistryReadOnly"))
             self.output_props["default_role"] = default_role
 
     def create_nlb(self, props):
@@ -36,6 +38,7 @@ class Ec2CdkStack(core.Stack):
                                          vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC))
 
             self.output_props["nlb"] = nlb
+            self.output_props["nlb_dns_name"] = nlb.load_balancer_dns_name
 
     def create_asg(self, service_type):
         if service_type == "web":

--- a/aws_cdk/web_cdk/userdata_web.sh
+++ b/aws_cdk/web_cdk/userdata_web.sh
@@ -2,9 +2,23 @@
 # 테스트를 위한 샘플 코드
 
 yum update -y
-yum install httpd -y
 
-#enable and start httpd
+# install docker
+amazon-linux-extras install -y docker
+service docker start
+usermod -a -G docker ec2-user
+usermod -a -G docker ssm-user
+chkconfig docker on
+curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+# install aws cli v2
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+
+# install httpd
+yum install httpd -y
 systemctl enable httpd
 systemctl start httpd
 echo "<html><head><title> Example Web Server</title></head>" >  /var/www/html/index.html

--- a/deploy/aws_event_bridge.json
+++ b/deploy/aws_event_bridge.json
@@ -1,0 +1,21 @@
+{
+  "source": [
+    "aws.ecr"
+  ],
+  "detail-type": [
+    "ECR Image Action"
+  ],
+  "detail": {
+    "action-type": [
+      "PUSH",
+      "DELETE"
+    ],
+    "result": [
+      "SUCCESS",
+      "FAILURE"
+    ],
+    "repository-name": [
+      "nomad-cafe"
+    ]
+  }
+}

--- a/deploy/lambda.py
+++ b/deploy/lambda.py
@@ -1,0 +1,56 @@
+import boto3
+import logging
+from botocore.config import Config
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+conf = Config(region_name="ap-northeast-2")
+ec2 = boto3.client('ec2', config=conf)
+ssm = boto3.client('ssm', config=conf)
+
+
+def lambda_handler(event, context):
+    try:
+        ec2_resp = ec2.describe_instances(Filters=[{'Name': 'instance-state-name', 'Values': ['running']}])
+
+        ec2_count = len(ec2_resp['Reservations'])
+        if ec2_count == 0:
+            logger.info('No EC2 is running')
+
+        account = event["account"]
+        repository_name = event["detail"]["repository-name"]
+        # image_tag = event["detail"]["image-tag"]
+
+        # 버전 체계 잡히기 전까지는 latest로 배포
+        docker_image = f"{account}.dkr.ecr.ap-northeast-2.amazonaws.com/{repository_name}:latest"
+        logger.info(docker_image)
+
+        # Get All InstanceID
+        instances = [i["InstanceId"] for r in ec2_resp["Reservations"] for i in r["Instances"]]
+        logger.info(instances)
+        ssm.send_command(
+            InstanceIds=instances,
+            DocumentName="AWS-RunShellScript",
+            CloudWatchOutputConfig={
+                "CloudWatchLogGroupName": "nomad-cafe-deploy",
+                "CloudWatchOutputEnabled": True
+
+            },
+            Parameters={
+                "commands": [
+                    "aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS "
+                    "--password-stdin 992189553983.dkr.ecr.ap-northeast-2.amazonaws.com",
+                    "cd /home/ssm-user",
+                    "docker-compose pull",
+                    "docker-compose stop web",
+                    "docker-compose rm web",
+                    "docker-compose up -d"
+                ],
+                "executionTimeout": ["3600"]
+            },
+        )
+
+    except Exception as e:
+        logger.error(e)
+        raise e


### PR DESCRIPTION
- 웹 서버가 실행되고 있는 EC2 인스턴스는 외부 접근이 불가능한 Private 서브넷에 생성되어 있다.
- 배포 자동화를 위해서는 외부에서 대상 EC2 인스턴스로 SSH 접속이 가능해야 한다.
- Github Action으로 배포 할 경우 Github Action 스크립트가 실행되는 Github 쪽 서버의 ACL이 허용되어 있어야 하지만 Github Action이 실행되는 서버는 불특정 다수의 Ip를 사용한다.
- ECR로 이미지만 push되면 해당 이벤트에 의해 Github과는 별개로 배포가 진행되도록 구성하기 위해 AWS EventBridge를 활용한다.
- 대안으로 Elastic beanstalk 사용하면 빌드 트리거만 하면 되어서 더 심플하게 구성 가능할 듯
![스크린샷 2020-08-09 오후 7 57 06](https://user-images.githubusercontent.com/15684652/89732475-1f147d80-da8a-11ea-9484-36ec53ad6285.png)

## Github Action 관련 내용
- 참고 : https://github.com/depromeet/nomad-cafe-server/pull/7